### PR TITLE
Resolved issue with entries not being removed.

### DIFF
--- a/src/vuex/store.js
+++ b/src/vuex/store.js
@@ -68,7 +68,7 @@ const mutations = {
   },
   EDIT_FIELD (state, field) {
     state.editor.action = 'edit'
-    state.clone = $.extend({}, field)
+    state.clone = field
   },
   DELETE_FIELD (state, field) {
     state.profile[field.type].$remove(field)


### PR DESCRIPTION
$.extend creates a brand new object which means that `state.profile.phones[someIndex] !== state.clone`.